### PR TITLE
feat: adding summary object

### DIFF
--- a/core/include/actsvg/core/svg.hpp
+++ b/core/include/actsvg/core/svg.hpp
@@ -31,6 +31,18 @@ namespace svg {
  **/
 struct object {
 
+    /** Nested summary struct
+     *
+     * This struct allows for defining some summary
+     * information with which this object has been 
+     * create.
+     * 
+     **/
+    struct summary {
+        std::array<scalar,2> _scale = {1.,1.};
+    };
+
+
     /// SVG tag of the objec
     std::string _tag = "";
 
@@ -80,6 +92,9 @@ struct object {
     /// Range in phi - view frame
     std::array<scalar, 2> _phi_range = {std::numeric_limits<scalar>::max(),
                                         std::numeric_limits<scalar>::lowest()};
+
+    /// Summary object 
+    summary _summary;
 
     /** An object is defined if a tag is set */
     bool is_defined() const { return (not _tag.empty()); }

--- a/meta/include/actsvg/display/sheets.hpp
+++ b/meta/include/actsvg/display/sheets.hpp
@@ -79,6 +79,9 @@ svg::object surface_sheet_xy(const std::string& id_,
     style::transform scale_transform;
     scale_transform._scale = {s_x, s_y};
 
+    // Remember the scale this has been done with
+    so._summary._scale = scale_transform._scale;
+
     // Copy in order to modify the transform
     proto::surface<point3_container> draw_surface = s_;
     draw_surface._transform._scale = {s_x, s_y};
@@ -552,6 +555,7 @@ svg::object surface_sheet_xy(const std::string& id_,
                  static_cast<scalar>(__m_font._size + end_r[1])});
             so.add_object(measure_r);
         }
+
     }
     return so;
 }
@@ -585,6 +589,9 @@ svg::object sheet(const std::string& id_,
         v_, view, sh_, lT == e_endcap, t_ == e_module_info, lT == e_endcap);
     auto x_axis = axes[0];
     auto y_axis = axes[1];
+
+    // Remember the scale with which this has been done
+    o_sheet._summary._scale = scale_transform._scale;
 
     // Set the info according to the sheet type
     for (auto [is, s] : utils::enumerate(v_._surfaces)) {


### PR DESCRIPTION
This adds a summary object to the `sag::object` class that allows to log some creation history in case it is needed later on.