### PR TITLE
fix: adding cluster channel id

### DIFF
--- a/meta/include/actsvg/proto/cluster.hpp
+++ b/meta/include/actsvg/proto/cluster.hpp
@@ -22,7 +22,7 @@ namespace proto {
 template <size_t DIM = 1>
 struct channel {
     /// Channel identification
-    std::array<scalar, DIM> _cid;
+    std::array<unsigned int, DIM> _cid;
     /// The data
     scalar _data;
 };


### PR DESCRIPTION
This PR fixes the channel identification which was `scalar` to `unsigned int`