### PR TITLE
feat: inserting showcase of a possible chamber viewer

### DIFF
--- a/meta/include/actsvg/proto/cluster.hpp
+++ b/meta/include/actsvg/proto/cluster.hpp
@@ -35,7 +35,7 @@ struct channel {
 template <size_t DIM = 1>
 struct cluster {
 
-    enum type { e_cartesian, e_fan, e_polar };
+    enum type { e_cartesian, e_fan, e_polar, e_drift };
 
     enum coordinate { e_x, e_y, e_r, e_phi };
 


### PR DESCRIPTION
I have inserted a possible implementation of a wire viewer, this should then be adapted in ACTS to use the `Acts::Measurement`.

<img width="587" alt="Screenshot 2023-02-25 at 13 32 34" src="https://user-images.githubusercontent.com/26623879/221357047-701d7772-c73b-4958-ab67-9c33a524e4c5.png">

It should help debugging the segment finder imported from the MS, there are several open item left:
- [ ] we should color the drift circles by sign (in order to get the left-right solution correct
- [ ] we can color the active tubes (I tried to do, but somehow I failed in the PR)

@noemina @dimitra97 @paulgessinger 