### PR TITLE
feat: adding meta::grid display

### DIFF
--- a/meta/include/actsvg/display/geometry.hpp
+++ b/meta/include/actsvg/display/geometry.hpp
@@ -172,18 +172,18 @@ svg::object surface(const std::string& id_, const surface_type& s_,
     } else if (s_._type == surface_type::type::e_straw) {
 
         // xy view
-        if constexpr (std::is_same_v<view_type, views::x_y>) { 
-             // Skin of the straw
-             auto ss = draw::circle(id_, {0., 0.}, s_._radii[1u], s_._fill,
-                              s_._stroke, draw_transform);
-             // Wire of the straw
-             auto ws = draw::circle(id_, {0., 0.}, s_._radii[0u], __s_fill,
-                              s_._stroke, draw_transform);
-             s._tag = "g";
-             s.add_object(ss);
-             s.add_object(ws);
-        }    
-    
+        if constexpr (std::is_same_v<view_type, views::x_y>) {
+            // Skin of the straw
+            auto ss = draw::circle(id_, {0., 0.}, s_._radii[1u], s_._fill,
+                                   s_._stroke, draw_transform);
+            // Wire of the straw
+            auto ws = draw::circle(id_, {0., 0.}, s_._radii[0u], __s_fill,
+                                   s_._stroke, draw_transform);
+            s._tag = "g";
+            s.add_object(ss);
+            s.add_object(ws);
+        }
+
     } else if (not s_._vertices.empty()) {
 
         // View activiation, deactivation

--- a/meta/include/actsvg/display/grids.hpp
+++ b/meta/include/actsvg/display/grids.hpp
@@ -1,0 +1,57 @@
+// This file is part of the actsvg packge.
+//
+// Copyright (C) 2022 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "actsvg/core.hpp"
+#include "actsvg/proto/grid.hpp"
+#include "actsvg/styles/defaults.hpp"
+
+namespace actsvg {
+
+using namespace defaults;
+
+namespace display {
+
+/** Draw a grid
+ *
+ * @param id_ the identification of this grid
+ * @param g_ the grid to be drawn
+ *
+ * @return an svg object representing the grid
+ */
+svg::object grid(const std::string& id_, const proto::grid& g_) {
+
+    svg::object g;
+
+    if (g_._type == proto::grid::type::e_r_phi) {
+        g = draw::tiled_polar_grid(id_, g_._edges_0, g_._edges_1, __g_fill,
+                                   __g_stroke);
+    } else {
+
+        std::vector<scalar> edges_1 = g_._edges_1;
+        if (g_._type == proto::grid::type::e_z_phi) {
+            std::for_each(edges_1.begin(), edges_1.end(),
+                          [&](auto& e) { e *= g_._reference_r; });
+        }
+
+        g = draw::tiled_cartesian_grid(id_, g_._edges_0, edges_1, __g_fill,
+                                       __g_stroke);
+    }
+
+    return g;
+}
+
+}  // namespace display
+}  // namespace actsvg

--- a/meta/include/actsvg/proto/grid.hpp
+++ b/meta/include/actsvg/proto/grid.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <vector>
 #include <string>
+#include <vector>
 
 #include "actsvg/core/defs.hpp"
 
@@ -17,29 +17,30 @@ namespace actsvg {
 
 namespace proto {
 
-    /** A proto grid class to describe the grid setup
-     * 
-     * For convenience, it is forced to be 2-dimensional, for 1-dim
-     * grid descriptions, only provide 2 eges
-     * 
-     */
-    struct grid {
+/** A proto grid class to describe the grid setup
+ *
+ * For convenience, it is forced to be 2-dimensional, for 1-dim
+ * grid descriptions, only provide 2 eges
+ *
+ */
+struct grid {
 
-        /** Type of grid, enum defintion */ 
-        enum type { e_x_y = 0, e_r_phi = 1, e_z_phi };
+    /** Type of grid, enum defintion */
+    enum type { e_x_y = 0, e_r_phi = 1, e_z_phi };
 
-        /// Name the type
-        type _type = e_r_phi;
+    /// Name the type
+    type _type = e_r_phi;
 
-        /// The edges in the two given directions, loc0
-        std::vector<scalar> _edges_0 = {};
-        
-        /// The edges in the two given directions, loc1
-        std::vector<scalar> _edges_1 = {};
-        
-    };
+    /// The edges in the two given directions, loc0
+    std::vector<scalar> _edges_0 = {};
+
+    /// The edges in the two given directions, loc1
+    std::vector<scalar> _edges_1 = {};
+
+    /// Reference r for drawing
+    scalar _reference_r = 0.;
+};
 
 }  // namespace proto
 
 }  // namespace actsvg
-

--- a/tests/meta/grid.cpp
+++ b/tests/meta/grid.cpp
@@ -1,20 +1,98 @@
 // This file is part of the actsvg packge.
 //
-// Copyright (C) 2022 CERN for the benefit of the ACTS project
+// Copyright (C) 2023 CERN for the benefit of the ACTS project
 //
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "actsvg/proto/grid.hpp"
+
 #include <gtest/gtest.h>
 
-#include "actsvg/proto/grid.hpp"
+#include "actsvg/display/grids.hpp"
+#include "actsvg/styles/defaults.hpp"
 
 using namespace actsvg;
 
-TEST(proto, grid) {
+TEST(proto, grid_x_y) {
+
+    proto::grid g;
+    g._type = proto::grid::type::e_x_y;
+    ASSERT_TRUE(g._type == proto::grid::type::e_x_y);
+
+    g._edges_0 = {-200, -100, 0, 100, 200};
+    g._edges_1 = {-500, -100, 0, 200.};
+
+    svg::object d_grid_x_y = display::grid("grid_x_y", g);
+
+    svg::file gfile_x_y;
+    gfile_x_y.add_object(d_grid_x_y);
+
+    std::ofstream rstream;
+    rstream.open("test_meta_grid_x_y.svg");
+    rstream << gfile_x_y;
+    rstream.close();
+}
+
+TEST(proto, grid_z_phi_closed) {
+
+    proto::grid g;
+    g._type = proto::grid::type::e_z_phi;
+    g._reference_r = 100.;
+    ASSERT_TRUE(g._type == proto::grid::type::e_z_phi);
+
+    g._edges_0 = {-200, -100, 0, 100, 200};
+    g._edges_1 = {-0.75 * M_PI, -0.5 * M_PI, -0.25 * M_PI,
+                  0.,           0.25 * M_PI, 0.5 * M_PI};
+
+    svg::object d_grid_z_phi = display::grid("grid_z_phi", g);
+
+    svg::file gfile_z_phi;
+    gfile_z_phi.add_object(d_grid_z_phi);
+
+    std::ofstream rstream;
+    rstream.open("test_meta_grid_z_phi.svg");
+    rstream << gfile_z_phi;
+    rstream.close();
+}
+
+TEST(proto, grid_r_phi_open) {
 
     proto::grid g;
     ASSERT_TRUE(g._type == proto::grid::type::e_r_phi);
 
+    g._edges_0 = {200., 300., 400., 500.};
+    g._edges_1 = {-0.75 * M_PI, -0.5 * M_PI, -0.25 * M_PI,
+                  0.,           0.25 * M_PI, 0.5 * M_PI};
+
+    svg::object d_grid_r_phi = display::grid("grid_r_phi", g);
+
+    svg::file gfile_r_phi;
+    gfile_r_phi.add_object(d_grid_r_phi);
+
+    std::ofstream rstream;
+    rstream.open("test_meta_grid_r_phi_open.svg");
+    rstream << gfile_r_phi;
+    rstream.close();
+}
+
+TEST(proto, grid_r_phi_full) {
+
+    proto::grid g;
+    ASSERT_TRUE(g._type == proto::grid::type::e_r_phi);
+
+    g._edges_0 = {200., 300., 400., 500.};
+    g._edges_1 = {-M_PI,       -0.75 * M_PI, -0.5 * M_PI, -0.25 * M_PI, 0.,
+                  0.25 * M_PI, 0.5 * M_PI,   0.75 * M_PI, M_PI};
+
+    svg::object d_grid_r_phi = display::grid("grid_r_phi", g);
+
+    svg::file gfile_r_phi;
+    gfile_r_phi.add_object(d_grid_r_phi);
+
+    std::ofstream rstream;
+    rstream.open("test_meta_grid_r_phi_full.svg");
+    rstream << gfile_r_phi;
+    rstream.close();
 }


### PR DESCRIPTION
This PR adds basic grid viewing of the `proto::grid` class. Nothing fancy.

<img width="714" alt="Screenshot 2023-03-29 at 22 09 12" src="https://user-images.githubusercontent.com/26623879/228655716-c13467cc-a692-480e-8b2c-dd6163ecfda8.png">
