### PR TITLE
fixing visualisation issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project (actsvg VERSION 0.1 LANGUAGES CXX )
+project (actsvg VERSION 0.4.35 LANGUAGES CXX )
 
 # Set up the used C++ standard(s).
 set( CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard to use" )


### PR DESCRIPTION
Fixes visualisation issue when rectangular surfaces are split across phi boundaries. If only one vertex is beyond the boundary, you want to re-evaluate the intersection with the grid in order to properly visualise the split surfaces.