### PR TITLE
Added customizeable marker stroke to markers of type "x"

### DIFF
--- a/core/include/actsvg/core/draw.hpp
+++ b/core/include/actsvg/core/draw.hpp
@@ -999,9 +999,9 @@ static inline svg::object marker(const std::string &id_, const point2 &at_,
         scalar a_y = at_[1];
         scalar h_s = 0.5 * size;
         marker_group.add_object(
-            line(id_ + "_ml0", {a_x - h_s, a_y - h_s}, {a_x + h_s, a_y + h_s}));
+            line(id_ + "_ml0", {a_x - h_s, a_y - h_s}, {a_x + h_s, a_y + h_s}, marker_._stroke));
         marker_group.add_object(
-            line(id_ + "_ml1", {a_x - h_s, a_y + h_s}, {a_x + h_s, a_y - h_s}));
+            line(id_ + "_ml1", {a_x - h_s, a_y + h_s}, {a_x + h_s, a_y - h_s}, marker_._stroke));
     }
 
     // Plot the arrow if not empty


### PR DESCRIPTION
Fixed a bug where markers of type "x" would always use the default stroke.

**Before** (custom marker stroke style not applied)
<img src="https://github.com/acts-project/actsvg/assets/92879080/85f11c9a-2c47-4cc4-853c-ee54e2fd4dbc" width="250" height="250">

**After**  (custom marker stroke style applied)
<img src="https://github.com/acts-project/actsvg/assets/92879080/b5cac9f2-9586-49b2-b266-1318288f88d0" width="250" height="250">