### PR TITLE
feat: Add surface type to proto surface.

### DIFF
--- a/core/include/actsvg/core/draw.hpp
+++ b/core/include/actsvg/core/draw.hpp
@@ -180,7 +180,7 @@ static inline svg::object arc(
 static inline svg::object bezier(
     const std::string &id_, const std::vector<std::array<point2, 2u>> &xds_,
     const style::stroke &stroke_ = style::stroke(),
-    const style::transform &transform_ = style::transform()) {
+    const style::transform & /*transform_*/ = style::transform()) {
 
     svg::object c;
     c._tag = "g";
@@ -998,10 +998,10 @@ static inline svg::object marker(const std::string &id_, const point2 &at_,
         scalar a_x = at_[0];
         scalar a_y = at_[1];
         scalar h_s = 0.5 * size;
-        marker_group.add_object(
-            line(id_ + "_ml0", {a_x - h_s, a_y - h_s}, {a_x + h_s, a_y + h_s}, marker_._stroke));
-        marker_group.add_object(
-            line(id_ + "_ml1", {a_x - h_s, a_y + h_s}, {a_x + h_s, a_y - h_s}, marker_._stroke));
+        marker_group.add_object(line(id_ + "_ml0", {a_x - h_s, a_y - h_s},
+                                     {a_x + h_s, a_y + h_s}, marker_._stroke));
+        marker_group.add_object(line(id_ + "_ml1", {a_x - h_s, a_y + h_s},
+                                     {a_x + h_s, a_y - h_s}, marker_._stroke));
     }
 
     // Plot the arrow if not empty

--- a/meta/include/actsvg/proto/surface.hpp
+++ b/meta/include/actsvg/proto/surface.hpp
@@ -42,6 +42,8 @@ struct surface {
         e_trapez
     };
 
+    enum class sf_type { e_portal, e_sensitive, e_passive };
+
     enum class boolean { e_clipping, e_union, e_subtraction, e_none };
 
     /// Name of the surface
@@ -70,6 +72,7 @@ struct surface {
 
     /// Type of the surfaces
     type _type = type::e_trapez;
+    sf_type _sf_type = sf_type::e_sensitive;
 
     /// And their measures
     std::vector<scalar> _measures = {};
@@ -90,6 +93,7 @@ struct surface {
         surface<point3_container> s;
         s._name = name_;
         s._type = t_._type;
+        s._sf_type = t_._sf_type;
         s._aux_info = t_._aux_info;
         s._vertices = t_._vertices;
         s._measures = t_._measures;

--- a/tests/meta/barrel_sheet.cpp
+++ b/tests/meta/barrel_sheet.cpp
@@ -53,6 +53,8 @@ proto::volume<point3_container> generate_barrel(
     barrel_module_template._measures = {hx, hy};
     barrel_module_template._type =
         proto::surface<point3_container>::type::e_rectangle;
+    barrel_module_template._sf_type =
+        proto::surface<point3_container>::sf_type::e_sensitive;
 
     scalar offz = (0.5 * stave_modules - 0.5) * (1.98 * hy);
     scalar nexz = offz / (0.5 * stave_modules - 0.5);
@@ -120,6 +122,7 @@ proto::volume<point3_container> generate_barrel(
                 barrel_module._vertices = {ll, lr, hr, hl};
                 barrel_module._measures = barrel_module_template._measures;
                 barrel_module._type = barrel_module_template._type;
+                barrel_module._sf_type = barrel_module_template._sf_type;
                 barrel_module._aux_info["module_info"] = {
                     std::string("Module " + std::to_string(is) + " " +
                                 std::to_string(iz)),
@@ -160,6 +163,10 @@ proto::volume<point3_container> generate_barrel(
                     barrel_module_backside._measures =
                         barrel_module_template._measures;
                     barrel_module_backside._type = barrel_module_template._type;
+                    barrel_module_backside._sf_type =
+                        barrel_module_template._sf_type;
+                    barrel_module_backside._sf_type =
+                        barrel_module_template._sf_type;
                     barrel_module_backside._aux_info["module_info"] = {
                         std::string("Module (backside) " + std::to_string(is) +
                                     " " + std::to_string(iz)),

--- a/tests/meta/detector.cpp
+++ b/tests/meta/detector.cpp
@@ -60,6 +60,7 @@ TEST(proto, cylindrical_detector) {
     proto::portal<point3_container> bp_nec;
     proto::surface<point3_container> bp_s_nec;
     bp_s_nec._type = proto::surface<point3_container>::type::e_disc;
+    bp_s_nec._sf_type = proto::surface<point3_container>::sf_type::e_portal;
     bp_s_nec._radii = {0., 40.};
     bp_s_nec._zparameters = {-400., 0.};
 
@@ -76,6 +77,7 @@ TEST(proto, cylindrical_detector) {
     nec._name = "joint_nec";
     proto::surface<point3_container> s_nec;
     s_nec._type = proto::surface<point3_container>::type::e_disc;
+    s_nec._sf_type = proto::surface<point3_container>::sf_type::e_portal;
     s_nec._radii = {0., 100.};
     s_nec._zparameters = {-400., 0.};
 
@@ -98,6 +100,7 @@ TEST(proto, cylindrical_detector) {
     ci._name = "joint_c_i";
     proto::surface<point3_container> s_ci;
     s_ci._type = proto::surface<point3_container>::type::e_cylinder;
+    s_ci._sf_type = proto::surface<point3_container>::sf_type::e_portal;
     s_ci._radii = {0., 40.};
     s_ci._zparameters = {0., 400.};
 
@@ -154,6 +157,7 @@ TEST(proto, cylindrical_detector) {
     co._name = "joint_c_o";
     proto::surface<point3_container> s_co;
     s_co._type = proto::surface<point3_container>::type::e_cylinder;
+    s_co._sf_type = proto::surface<point3_container>::sf_type::e_portal;
     s_co._radii = {0., 100.};
     s_co._zparameters = {0., 400.};
 
@@ -182,6 +186,7 @@ TEST(proto, cylindrical_detector) {
     pix_nec_b._name = "pix_nec_b";
     proto::surface<point3_container> s_pix_nec_b;
     s_pix_nec_b._type = proto::surface<point3_container>::type::e_disc;
+    s_pix_nec_b._sf_type = proto::surface<point3_container>::sf_type::e_portal;
     s_pix_nec_b._radii = {40., 100.};
     s_pix_nec_b._zparameters = {-300., 0.};
 
@@ -205,6 +210,7 @@ TEST(proto, cylindrical_detector) {
     pix_b_pec._name = "pix_b_pec";
     proto::surface<point3_container> s_pix_b_pec;
     s_pix_b_pec._type = proto::surface<point3_container>::type::e_disc;
+    s_pix_b_pec._sf_type = proto::surface<point3_container>::sf_type::e_portal;
     s_pix_b_pec._radii = {40., 100.};
     s_pix_b_pec._zparameters = {300., 0.};
 

--- a/tests/meta/endcap_sheet.cpp
+++ b/tests/meta/endcap_sheet.cpp
@@ -71,6 +71,8 @@ proto::volume<point3_container> generate_endcap(
     if (m_t_ == proto::surface<point3_container>::type::e_disc) {
 
         inner_template_surface._type = m_t_;
+        inner_template_surface._sf_type =
+            proto::surface<point3_container>::sf_type::e_sensitive;
         inner_template_surface._radii = {100, 200};
         inner_template_surface._opening = {
             static_cast<scalar>(-half_opening - 0.05),
@@ -80,6 +82,8 @@ proto::volume<point3_container> generate_endcap(
 
         middle_template_surface._type =
             proto::surface<point3_container>::type::e_disc;
+        middle_template_surface._sf_type =
+            proto::surface<point3_container>::sf_type::e_sensitive;
         middle_template_surface._radii = {190, 320};
         middle_template_surface._opening = {
             static_cast<scalar>(-half_opening - 0.05),
@@ -89,6 +93,8 @@ proto::volume<point3_container> generate_endcap(
 
         outer_template_surface._type =
             proto::surface<point3_container>::type::e_disc;
+        outer_template_surface._sf_type =
+            proto::surface<point3_container>::sf_type::e_sensitive;
         outer_template_surface._radii = {310, 450};
         outer_template_surface._opening = {
             static_cast<scalar>(-half_opening - 0.05),
@@ -100,6 +106,8 @@ proto::volume<point3_container> generate_endcap(
 
     } else if (m_t_ == proto::surface<point3_container>::type::e_trapez) {
         inner_template_surface._type = m_t_;
+        inner_template_surface._sf_type =
+            proto::surface<point3_container>::sf_type::e_sensitive;
         inner_template_surface._measures = {26., 40., 55.};
         inner_template_surface._vertices = {
             {-inner_template_surface._measures[0],
@@ -112,6 +120,8 @@ proto::volume<point3_container> generate_endcap(
              inner_template_surface._measures[2], 0}};
 
         middle_template_surface._type = m_t_;
+        middle_template_surface._sf_type =
+            proto::surface<point3_container>::sf_type::e_sensitive;
         middle_template_surface._measures = {40., 68., 75.};
         middle_template_surface._vertices = {
             {-middle_template_surface._measures[0],
@@ -124,6 +134,8 @@ proto::volume<point3_container> generate_endcap(
              middle_template_surface._measures[2], 0}};
 
         outer_template_surface._type = m_t_;
+        outer_template_surface._sf_type =
+            proto::surface<point3_container>::sf_type::e_sensitive;
         outer_template_surface._measures = {68., 100., 75.};
         outer_template_surface._vertices = {
             {-outer_template_surface._measures[0],
@@ -176,6 +188,7 @@ proto::volume<point3_container> generate_endcap(
                 // (b) as individual objects
                 s._name = ts._name + std::to_string(isc);
                 s._type = ts._type;
+                s._sf_type = ts._sf_type;
                 s._aux_info = ts._aux_info;
                 s._vertices = ts._vertices;
                 s._measures = ts._measures;
@@ -283,6 +296,8 @@ proto::volume<point3_container> generate_endcap(
         proto::surface<point3_container> support_disk;
         support_disk._name = "support_disk";
         support_disk._type = proto::surface<point3_container>::type::e_disc;
+        support_disk._sf_type =
+            proto::surface<point3_container>::sf_type::e_passive;
         scalar r_min = 100.;
         scalar r_max = 450.;
         point3 A = {r_max, 0., 0.};

--- a/tests/meta/grid.cpp
+++ b/tests/meta/grid.cpp
@@ -127,7 +127,7 @@ TEST(proto, grid_r_phi_full) {
             std::string tile_name = std::string("tile_") + std::to_string(i0) +
                                     std::string("_") + std::to_string(i1);
 
-            point2 text_pos = {r * cos(phi), r * sin(phi)};
+            point2 text_pos = {r * std::cos(phi), r * std::sin(phi)};
             tile_ids.push_back(
                 draw::text(tile_name, text_pos, {global_id, local_id}));
         }

--- a/tests/meta/portal.cpp
+++ b/tests/meta/portal.cpp
@@ -31,6 +31,7 @@ TEST(proto, cylinder_portal) {
 
     proto::surface<point3_container> s;
     s._type = proto::surface<point3_container>::type::e_cylinder;
+    s._sf_type = proto::surface<point3_container>::sf_type::e_portal;
     s._radii = {0., 100.};
     s._zparameters = {0., 200.};
 
@@ -83,6 +84,7 @@ TEST(proto, full_disc_portal) {
 
     proto::surface<point3_container> s;
     s._type = proto::surface<point3_container>::type::e_disc;
+    s._sf_type = proto::surface<point3_container>::sf_type::e_portal;
     s._radii = {10., 100.};
     s._zparameters = {50., 0.};
     s._fill = defaults::__nn_fill;

--- a/tests/meta/wire_chamber.cpp
+++ b/tests/meta/wire_chamber.cpp
@@ -81,7 +81,7 @@ std::optional<proto::cluster<1u>> drift_cluster(
                           std::sin(alpha_) * (start_[0u] - t[0u]));
 
     if (d_r <= s_._radii[1u]) {
-        proto::cluster<1u> drift_cluster;
+        proto::cluster<1u> drift_cluster{};
         drift_cluster._type = proto::cluster<1u>::type::e_drift;
         drift_cluster._coords = {proto::cluster<1u>::coordinate::e_r};
         drift_cluster._measurement = {d_r};


### PR DESCRIPTION
Add surface type (portal, sensitive, passive) to proto surface. This eases picking color schemes for the three types of surfaces in downstream projects. Also fixes a few warnings