### PR TITLE
feat: trajectory and seed support in xy

### DIFF
--- a/meta/include/actsvg/display/geometry.hpp
+++ b/meta/include/actsvg/display/geometry.hpp
@@ -202,7 +202,7 @@ svg::object surface(const std::string& id_, const surface_type& s_,
             s._active = view_active;
             return s;
         }
-        auto view_vertices = v_(s_._vertices);
+        auto view_vertices = v_.path(s_._vertices);
 
         if constexpr (std::is_same_v<view_type, views::z_rphi>) {
             // Check if we have to split the surface in phi and
@@ -254,7 +254,7 @@ svg::object surface(const std::string& id_, const surface_type& s_,
                             n_vertices.push_back(add);
                         }
 
-                        auto p_view_vertices = v_(p_vertices);
+                        auto p_view_vertices = v_.path(p_vertices);
                         auto p_middle = p_view_vertices.back();
                         p_middle[1u] = static_cast<scalar>(
                             1.5 * p_view_vertices.back()[1u] -
@@ -267,7 +267,7 @@ svg::object surface(const std::string& id_, const surface_type& s_,
                                                p_middle);
 
                         auto s_n = draw::polygon(id_ + std::string("_n_split"),
-                                                 v_(n_vertices), s_._fill,
+                                                 v_.path(n_vertices), s_._fill,
                                                  s_._stroke, draw_transform);
 
                         auto s_p = draw::polygon(id_ + std::string("_p_split"),
@@ -304,7 +304,7 @@ svg::object surface(const std::string& id_, const surface_type& s_,
                     n_vertices.push_back(n4);
 
                     auto s_n = draw::polygon(id_ + std::string("_n_split"),
-                                             v_(n_vertices), s_._fill,
+                                             v_.path(n_vertices), s_._fill,
                                              s_._stroke, draw_transform);
                     // Split art on positive side
                     auto p4 = p_vertices[0u];
@@ -318,7 +318,7 @@ svg::object surface(const std::string& id_, const surface_type& s_,
                     p_vertices.push_back(p3);
                     p_vertices.push_back(p4);
                     // Create the wiggle out (on view to not fall into phi trap)
-                    auto p_view_vertices = v_(p_vertices);
+                    auto p_view_vertices = v_.path(p_vertices);
                     const auto& p_v_1 = p_view_vertices[1u];
                     const auto& p_v_2 = p_view_vertices[2u];
                     auto& p_v_3 = p_view_vertices[3u];
@@ -450,7 +450,7 @@ svg::object portal_link(const std::string& id_,
     } else {
         typename portal_type::container_type start_end_3d = {link_._start,
                                                              link_._end};
-        auto start_end = v_(start_end_3d);
+        auto start_end = v_.path(start_end_3d);
 
         l.add_object(draw::arrow(id_ + "_arrow", start_end[0u], start_end[1u],
                                  link_._stroke, link_._start_marker,
@@ -506,7 +506,7 @@ svg::object volume(const std::string& id_, const volume_type& dv_,
 
     // The volume shape - only rz view currently supported
     if (not dv_._vertices.empty() and std::is_same_v<view_type, views::z_r>) {
-        auto view_vertices = v_(dv_._vertices);
+        auto view_vertices = v_.path(dv_._vertices);
         auto pv = draw::polygon(id_ + "_volume", view_vertices, dv_._fill,
                                 dv_._stroke, dv_._transform);
         v.add_object(pv);

--- a/meta/include/actsvg/display/helpers.hpp
+++ b/meta/include/actsvg/display/helpers.hpp
@@ -112,7 +112,7 @@ views::contour range_contour(const surface_type& s_,
         contour = {bbl, bbr};
     } else if (not s_._vertices.empty()) {
         // Plain contours are present
-        contour = view(s_._vertices);
+        contour = view.path(s_._vertices);
         if (not fs_) {
             std::for_each(contour.begin(), contour.end(), [&](auto& v) {
                 scalar alpha = s_._transform._rot[0];
@@ -142,7 +142,7 @@ views::contour range_contour(const surface_type& s_,
         point3 F = {ro * cos_phi_low, ro * sin_phi_low, 0.};
 
         std::vector<point3> vertices_disc = {A, B, C, D, E, F};
-        contour = view(vertices_disc);
+        contour = view.path(vertices_disc);
     } else {
         throw std::invalid_argument(
             "surface_sheet_xy(...) - could not estimate range.");

--- a/meta/include/actsvg/proto/track.hpp
+++ b/meta/include/actsvg/proto/track.hpp
@@ -1,0 +1,73 @@
+// This file is part of the actsvg packge.
+//
+// Copyright (C) 2022 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "actsvg/core/defs.hpp"
+#include "actsvg/proto/cluster.hpp"
+#include "actsvg/styles/defaults.hpp"
+
+namespace actsvg {
+namespace proto {
+
+template <typename point3_type>
+struct trajectory {
+
+    using point3 = point3_type;
+
+    /// The origin of the trajectory
+    point3_type _origin;
+
+    /// The direction of the trajectory
+    point3_type _direction;
+
+    /// The path of the trajectory, first positions, second optional directions
+    std::vector<std::pair<point3_type, std::optional<point3_type>>> _path;
+
+    /// The origin style
+    scalar _origin_size = 0.;
+    style::stroke _origin_stroke;
+    style::fill _origin_fill;
+
+    /// The trajectory style
+    style::marker _path_arrow;
+    style::stroke _path_stroke;
+};
+
+template <typename point3_type>
+struct seed {
+
+    /// The space pionts
+    std::vector<point3_type> _space_points;
+
+    /// The trajectory
+    std::optional<trajectory<point3_type>> _trajectory;
+
+    /// The space point style
+    scalar _space_point_size = 5.;
+    style::fill _space_point_fill;
+    style::stroke _space_point_stroke;
+};
+
+template <typename surface_type>
+struct track_state {
+    /// The surface
+    surface_type _surface;
+
+    /// The cluster
+    std::variant<cluster<1>, cluster<2>> _cluster;
+};
+
+}  // namespace proto
+
+}  // namespace actsvg

--- a/python/python/actsvg/__init__.py
+++ b/python/python/actsvg/__init__.py
@@ -1,6 +1,8 @@
 from .pyactsvg import *
 from . import pyactsvg
 from . import actsvg_json as json
+from . import actsvg_uproot as uproot
 from actsvg import io
 
 setattr(io, "json", json)
+

--- a/python/python/actsvg/actsvg_uproot.py
+++ b/python/python/actsvg/actsvg_uproot.py
@@ -1,0 +1,2 @@
+import actsvg
+import uproot as ur

--- a/tests/common/detector.hpp
+++ b/tests/common/detector.hpp
@@ -6,6 +6,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#pragma once
+
 #include <array>
 #include <vector>
 

--- a/tests/common/helix.hpp
+++ b/tests/common/helix.hpp
@@ -1,0 +1,75 @@
+// This file is part of the actsvg packge.
+//
+// Copyright (C) 2024 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <cmath>
+#include <vector>
+
+#include "actsvg/core/defs.hpp"
+#include "actsvg/proto/track.hpp"
+
+namespace actsvg {
+namespace test {
+
+/** Generate helix points along a helix with constant magnetic field
+ * along a z axis
+ *
+ * @tparam point3_type The point type
+ *
+ * @param[in] origin_ The particle origin
+ * @param[in] direction_ The particle direction
+ * @param[in] radius_ The radius of the helix
+ * @param[in] o_ The orientation of the helix (pos, neg)
+ * @param[in] phi_range_ The range of the phi angle (phi==0 is the origin)
+ * @param[in] step_size_ The step size
+ *
+ * @return The helix points
+ */
+template <typename point3_type>
+inline static proto::trajectory<point3_type> generate_helix(
+    const point3_type& origin_, const point3_type& direction_, scalar radius_,
+    scalar o_, std::array<scalar, 2u> phi_range_, std::size_t n_points_) {
+    // The helix points to be generated
+    proto::trajectory<point3_type> trj;
+    trj._origin = origin_;
+    trj._direction = direction_;
+
+    // Create the center of the helix
+    scalar t_l = std::sqrt(direction_[0] * direction_[0] +
+                           direction_[1] * direction_[1]);
+    point2 t_dir = {direction_[0] / t_l, direction_[1] / t_l};
+    point2 n_dir = {std::copysign(t_dir[1], o_), -std::copysign(t_dir[0], o_)};
+
+    point3_type center = origin_;
+    center[0] -= radius_ * n_dir[0];
+    center[1] -= radius_ * n_dir[1];
+
+    // Calculate phi0
+    scalar phi0 = std::atan2(origin_[1] - center[1], origin_[0] - center[0]);
+
+    // The number of steps
+    scalar phi_step = (phi_range_[1] - phi_range_[0]) / n_points_;
+
+    for (std::size_t i = 0; i < n_points_; ++i) {
+        scalar phi = phi_range_[0] + std::copysign(i, o_) * phi_step;
+        scalar x = center[0] + radius_ * std::cos(phi0 + phi);
+        scalar y = center[1] + radius_ * std::sin(phi0 + phi);
+        scalar z = center[2] + direction_[2] * phi;
+        // Create the current position
+        point3_type p{x, y, z};
+        // Create the direction
+        point3_type d{-std::sin(phi), std::cos(phi), direction_[2]};
+        trj._path.push_back({p, d});
+    }
+    // Return the trajectory
+    return trj;
+}
+
+}  // namespace test
+}  // namespace actsvg

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -14,6 +14,7 @@ actsvg_add_test( core
   "markers.cpp"
   "measures.cpp"
   "polygon.cpp"
+  "polyline.cpp"
   "rectangle.cpp"
   "style.cpp"
   "svg.cpp"

--- a/tests/core/barrel.cpp
+++ b/tests/core/barrel.cpp
@@ -37,7 +37,7 @@ TEST(barrel, x_y_view) {
     std::vector<svg::object> modules;
     for (auto [m, bm] : utils::enumerate(barrel_modules)) {
         std::string m_id = std::string("m") + std::to_string(m);
-        auto module_contour = x_y_view(bm);
+        auto module_contour = x_y_view.path(bm);
         modules.push_back(
             draw::polygon(m_id, module_contour, module_color, stroke_color));
     }
@@ -74,7 +74,7 @@ TEST(barrel, z_phi_view) {
     std::vector<svg::object> modules;
     for (auto [m, bm] : utils::enumerate(barrel_modules)) {
         std::string m_id = std::string("m") + std::to_string(m);
-        auto module_contour = z_phi_view(bm);
+        auto module_contour = z_phi_view.path(bm);
         modules.push_back(draw::polygon(m_id, module_contour, module_color,
                                         stroke_color, scale));
     }
@@ -122,7 +122,7 @@ TEST(barrel, z_phi_view_grid) {
     std::vector<svg::object> modules;
     for (auto [m, bm] : utils::enumerate(barrel_modules)) {
         std::string m_id = std::string("m") + std::to_string(m);
-        auto module_contour = z_phi_view(bm);
+        auto module_contour = z_phi_view.path(bm);
         modules.push_back(draw::polygon(m_id, module_contour, module_color,
                                         stroke_color, scale));
     }

--- a/tests/core/endcap.cpp
+++ b/tests/core/endcap.cpp
@@ -38,7 +38,7 @@ TEST(endcap, z_r_view) {
     std::vector<svg::object> modules;
     for (auto [m, ecm] : utils::enumerate(endcap_modules)) {
         std::string m_id = std::string("m") + std::to_string(m);
-        auto module_contour = z_r_view(ecm);
+        auto module_contour = z_r_view.path(ecm);
         modules.push_back(
             draw::polygon(m_id, module_contour, module_color, stroke_color));
     }
@@ -76,7 +76,7 @@ TEST(endcap, x_y_view) {
     for (auto [m, ecm] : utils::enumerate(endcap_modules)) {
         std::string m_id = std::string("m") + std::to_string(m);
         std::string t_id = std::string("t") + std::to_string(m);
-        auto module_contour = x_y_view(ecm);
+        auto module_contour = x_y_view.path(ecm);
         auto module =
             draw::polygon(m_id, module_contour, module_color, stroke_color);
         modules.push_back(module);
@@ -127,7 +127,7 @@ TEST(endcap, x_y_view_grid) {
     std::vector<svg::object> modules;
     for (auto [m, ecm] : utils::enumerate(endcap_modules)) {
         std::string m_id = std::string("m") + std::to_string(m);
-        auto module_contour = x_y_view(ecm);
+        auto module_contour = x_y_view.path(ecm);
         modules.push_back(
             draw::polygon(m_id, module_contour, module_color, stroke_color));
     }

--- a/tests/core/polyline.cpp
+++ b/tests/core/polyline.cpp
@@ -1,0 +1,36 @@
+// This file is part of the actsvg packge.
+//
+// Copyright (C) 2024 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+
+#include "../common/playground.hpp"
+#include "actsvg/core.hpp"
+
+using namespace actsvg;
+
+TEST(draw, polyline) {
+
+    // Set a playground
+    auto pg = test::playground({-400, -400}, {400, 400});
+
+    svg::file tfile;
+    std::vector<std::array<scalar, 2u>> line_points = {
+        {0, 0}, {10, 10}, {12, 20}, {18, 100}, {50, 105}};
+
+    auto pl = draw::polyline("lo", line_points);
+
+    tfile._objects.push_back(pg);
+    tfile._objects.push_back(pl);
+
+    std::ofstream tstream;
+    tstream.open("test_core_polyline.svg");
+    tstream << tfile;
+    tstream.close();
+}

--- a/tests/core/views.cpp
+++ b/tests/core/views.cpp
@@ -23,7 +23,7 @@ TEST(views, xy) {
     std::vector<point3> p3s = {{1., 2., 0.}, {3., 4., 0.}, {7., 8., 0.}};
 
     views::x_y x_y_view;
-    auto c = x_y_view(p3s);
+    auto c = x_y_view.path(p3s);
 
     ASSERT_TRUE(c.size() == 3u);
 
@@ -35,7 +35,7 @@ TEST(views, zr) {
     std::vector<point3> p3s = {{1., 0., 3.}, {0., 4., 0.}, {2., 2., 2.}};
 
     views::z_r z_r_view;
-    auto c = z_r_view(p3s);
+    auto c = z_r_view.path(p3s);
 
     ASSERT_TRUE(c.size() == 3u);
 
@@ -48,7 +48,7 @@ TEST(views, zphi) {
     std::vector<point3> p3s = {{1., 0., 3.}, {0., 4., 0.}, {2., 2., 2.}};
 
     views::z_phi z_phi_view;
-    auto c = z_phi_view(p3s);
+    auto c = z_phi_view.path(p3s);
 
     ASSERT_TRUE(c.size() == 3u);
 
@@ -61,7 +61,7 @@ TEST(views, zrphi) {
 
     views::z_rphi z_rphi_view;
     z_rphi_view._fixed_r = 2.;
-    auto c = z_rphi_view(p3s);
+    auto c = z_rphi_view.path(p3s);
 
     ASSERT_TRUE(c.size() == 3u);
 

--- a/tests/meta/CMakeLists.txt
+++ b/tests/meta/CMakeLists.txt
@@ -8,8 +8,10 @@ actsvg_add_test( meta
   "grid.cpp"
   "wire_chamber.cpp"
   "portal.cpp"
+  "seeds.cpp"
   "surface_sheet.cpp"
   "surface_materials.cpp"
   "surfaces.cpp"
+  "trajectories.cpp"
   "volume.cpp"
 LINK_LIBRARIES GTest::gtest_main actsvg::core actsvg::meta actsvg::data)

--- a/tests/meta/barrel_sheet.cpp
+++ b/tests/meta/barrel_sheet.cpp
@@ -223,7 +223,7 @@ TEST(display, barrel_x_y_view) {
         for (auto [m, bm] : utils::enumerate(surfaces)) {
             std::string m_id =
                 std::string("m_") + std::to_string(s) + "_" + std::to_string(m);
-            auto module_contour = x_y_view(bm._vertices);
+            auto module_contour = x_y_view.path(bm._vertices);
             modules.push_back(draw::polygon(m_id, module_contour, module_color,
                                             stroke_color));
         }

--- a/tests/meta/seeds.cpp
+++ b/tests/meta/seeds.cpp
@@ -1,0 +1,72 @@
+// This file is part of the actsvg packge.
+//
+// Copyright (C) 2022 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <fstream>
+
+#include "../common/helix.hpp"
+#include "actsvg/display/datamodel.hpp"
+#include "actsvg/proto/track.hpp"
+#include "actsvg/styles/defaults.hpp"
+
+using namespace actsvg;
+
+using point3 = std::array<scalar, 3u>;
+
+TEST(proto, seeds_single_xy) {
+
+    views::x_y xy_view;
+
+    std::vector<scalar> radii = {30., 50., 70.};
+    std::vector<svg::object> cylinders = {};
+    for (auto [ir, r] : utils::enumerate(radii)) {
+        cylinders.push_back(
+            draw::circle("l" + std::to_string(ir), {0., 0.}, r, __nn_fill));
+    }
+
+    point3 origin = {0., 0., 0.};
+    scalar oot = 1. / std::sqrt(3.);
+    point3 direction = {oot, oot, oot};
+    scalar radius = 100.;
+    scalar o = 1.;
+    std::array<scalar, 2u> phi_range = {-0.1, 0.35 * M_PI};
+    proto::trajectory<point3> trj = test::generate_helix<point3>(
+        origin, direction, radius, o, phi_range, 100);
+    trj._origin_size = 0.;
+    trj._origin_fill = defaults::__g_fill;
+    trj._origin_stroke = style::stroke{style::color{{0, 0, 0}}, 0.5};
+    trj._path_stroke = style::stroke{style::color{{0, 255, 0}}, 0.5};
+
+    proto::seed<point3> seed;
+    scalar s0x = 30. * std::cos(0.3 * M_PI);
+    scalar s0y = 30. * std::sin(0.3 * M_PI);
+    scalar s1x = 50. * std::cos(0.33 * M_PI);
+    scalar s1y = 50. * std::sin(0.33 * M_PI);
+    scalar s2x = 70. * std::cos(0.365 * M_PI);
+    scalar s2y = 70. * std::sin(0.365 * M_PI);
+
+    seed._space_points = {point3{s0x, s0y, 0.}, point3{s1x, s1y},
+                          point3{s2x, s2y, 0.}};
+    seed._trajectory = trj;
+    seed._space_point_size = 1.;
+    seed._space_point_fill = style::fill(style::color{{0, 255, 0}});
+
+    auto seed_traj_xy = display::seed("seed_xy", seed, xy_view);
+
+    std::ofstream rstream;
+
+    svg::file seed_xy;
+    seed_xy.add_objects(cylinders);
+    seed_xy.add_object(seed_traj_xy);
+
+    rstream.open("test_meta_single_seed_xy.svg");
+    rstream << seed_xy;
+    rstream.close();
+}

--- a/tests/meta/trajectories.cpp
+++ b/tests/meta/trajectories.cpp
@@ -1,0 +1,68 @@
+// This file is part of the actsvg packge.
+//
+// Copyright (C) 2022 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <fstream>
+
+#include "../common/helix.hpp"
+#include "../common/playground.hpp"
+#include "actsvg/display/datamodel.hpp"
+#include "actsvg/proto/track.hpp"
+#include "actsvg/styles/defaults.hpp"
+
+using namespace actsvg;
+
+using point3 = std::array<scalar, 3u>;
+
+TEST(proto, helix_trajectory) {
+
+    views::x_y xy_view;
+
+    point3 origin = {0., 0., 0.};
+    scalar oot = 1. / std::sqrt(3.);
+    point3 direction = {oot, oot, oot};
+    scalar radius = 100.;
+    scalar o = 1.;
+    std::array<scalar, 2u> phi_range = {-0.1, 0.75 * M_PI};
+    proto::trajectory<point3> trj_p = test::generate_helix<point3>(
+        origin, direction, radius, o, phi_range, 100);
+    trj_p._origin_size = 5.;
+    trj_p._origin_fill = defaults::__g_fill;
+    trj_p._origin_stroke = style::stroke{style::color{{0, 0, 0}}, 1.5};
+    trj_p._path_stroke = style::stroke{style::color{{0, 255, 0}}, 1.5};
+
+    auto trj_xy_polyline_p =
+        display::trajectory("helix_xy_polyline_p", trj_p, xy_view);
+
+    proto::trajectory<point3> trj_n = test::generate_helix<point3>(
+        origin, direction, 1.5 * radius, -o, phi_range, 100);
+    trj_n._origin_size = 5.;
+    trj_n._origin_fill = defaults::__g_fill;
+    trj_n._origin_stroke = style::stroke{style::color{{0, 0, 0}}, 1.5};
+    trj_n._path_arrow =
+        style::marker{">", 5.5, style::fill{style::color{{255, 0, 0}}}};
+    trj_n._path_stroke = style::stroke{style::color{{255, 0, 0}}, 1.5};
+
+    auto trj_xy_polyline_n =
+        display::trajectory("helix_xy_polyline_n", trj_n, xy_view);
+
+    // Set a playground
+    auto pg = test::playground({-400, -400}, {400, 400});
+
+    svg::file hfile;
+    hfile.add_object(pg);
+    hfile.add_object(trj_xy_polyline_p);
+    hfile.add_object(trj_xy_polyline_n);
+
+    std::ofstream rstream;
+    rstream.open("test_meta_helix_polyline_xy.svg");
+    rstream << hfile;
+    rstream.close();
+}


### PR DESCRIPTION
This PR adds support for trajectory and seed displaying

It also adds `point` and `path` view options for the `view` classes in order to allow single and contour views.

<img width="615" alt="Screenshot 2024-04-17 at 13 05 56" src="https://github.com/acts-project/actsvg/assets/26623879/527f4356-fbd8-4074-af92-af3599852b0b">
