### PR TITLE
fix: group transform for arrow heads

### DIFF
--- a/core/include/actsvg/core/style.hpp
+++ b/core/include/actsvg/core/style.hpp
@@ -153,7 +153,7 @@ struct stroke {
     /// Nothing is written out
     bool _sterile = false;
 
-    /// @brief Contructor for stroke 
+    /// @brief Contructor for stroke
     /// @param c_ the color of the stroke
     /// @param w_ the with of the stroke
     /// @param d_ the dashed harray of the stroke
@@ -258,6 +258,14 @@ struct transform {
 
     bool _sterile = false;
 
+    /** Test if it is a identity/sterile transform */
+    bool is_identity() const {
+        return _sterile or
+               (_tr[0] == 0. and _tr[1] == 0. and _rot[0] == 0. and
+                _rot[1] == 0. and _rot[2] == 0. and _skew[0] == 0. and
+                _skew[1] == 0. and _scale[0] == 1. and _scale[1] == 1.);
+    }
+
     /** Apply to a point
      *
      * @param p_ the point to be transformed
@@ -347,7 +355,6 @@ struct marker {
     fill _fill = fill{{{0, 0, 0}}};
 
     stroke _stroke = stroke();
-
 };
 
 // The axis marker types

--- a/core/include/actsvg/core/svg.hpp
+++ b/core/include/actsvg/core/svg.hpp
@@ -190,10 +190,12 @@ inline std::ostream &operator<<(std::ostream &os_, const object &o_) {
     }
 
     // Attach the styles: fill, stroke, transform
-    if (not o_._sterile and o_._tag != "g") {
+    if (not o_._sterile) {
         o_._fill.attach_attributes(o_copy);
         o_._stroke.attach_attributes(o_copy);
-        o_._transform.attach_attributes(o_copy);
+        if (not o_._transform.is_identity()) {
+            o_._transform.attach_attributes(o_copy);
+        }
     }
 
     // The attribute map
@@ -273,8 +275,8 @@ struct file {
      * @param os_ is the vector of objects
      **/
     void add_objects(const std::vector<svg::object> &os_) {
-        // Add the objects one by one 
-        for (const auto& o_  : os_)
+        // Add the objects one by one
+        for (const auto &o_ : os_)
             if (o_._active) {
                 _objects.push_back(o_);
             }

--- a/meta/include/actsvg/display/datamodel.hpp
+++ b/meta/include/actsvg/display/datamodel.hpp
@@ -336,7 +336,12 @@ static inline svg::object trajectory(const std::string& id,
     for (const auto& [pos, dir] : trajectory_._path) {
         points.push_back(view_.point(pos));
         if (dir.has_value()) {
-            directions.push_back(view_.point(dir.value()));
+            point2 dir2 = view_.point(dir.value());
+            // normalize the direction
+            scalar norm = std::sqrt(dir2[0] * dir2[0] + dir2[1] * dir2[1]);
+            dir2[0] /= norm;
+            dir2[1] /= norm;
+            directions.push_back(view_.point(dir2));
         }
     }
 

--- a/tests/common/helix.hpp
+++ b/tests/common/helix.hpp
@@ -64,7 +64,8 @@ inline static proto::trajectory<point3_type> generate_helix(
         // Create the current position
         point3_type p{x, y, z};
         // Create the direction
-        point3_type d{-std::sin(phi), std::cos(phi), direction_[2]};
+        point3_type d{-std::sin(phi + phi0), std::cos(phi + phi0),
+                      direction_[2]};
         trj._path.push_back({p, d});
     }
     // Return the trajectory

--- a/tests/meta/seeds.cpp
+++ b/tests/meta/seeds.cpp
@@ -43,6 +43,7 @@ TEST(proto, seeds_single_xy) {
     trj._origin_fill = defaults::__g_fill;
     trj._origin_stroke = style::stroke{style::color{{0, 0, 0}}, 0.5};
     trj._path_stroke = style::stroke{style::color{{0, 255, 0}}, 0.5};
+    trj._path_arrow = style::marker{"<<", 3., style::color{{0, 255, 0}}};
 
     proto::seed<point3> seed;
     scalar s0x = 30. * std::cos(0.3 * M_PI);


### PR DESCRIPTION
This PR fixes #59 by re-itroducing the explicit writing of group transforms (which was removed to avoid writing empty transforms everyhwere), instead now, transforms are always written if they are different from identity.

*Now*:

<img width="726" alt="Screenshot 2024-04-18 at 12 01 27" src="https://github.com/acts-project/actsvg/assets/26623879/e158b34f-2185-46fb-9de8-789efb01e4e5">

*Was*:

<img width="461" alt="Screenshot 2024-04-18 at 11 56 49" src="https://github.com/acts-project/actsvg/assets/26623879/9a0104a4-cb84-4d0e-992e-ddf082d20484">

@niermann999 