### PR TITLE
feat: adding labels and apply them

### DIFF
--- a/core/include/actsvg/core/style.hpp
+++ b/core/include/actsvg/core/style.hpp
@@ -15,6 +15,7 @@
 
 #include "defs.hpp"
 #include "utils.hpp"
+#include "views.hpp"
 
 namespace actsvg {
 
@@ -105,6 +106,9 @@ struct gradient {
 
     /// The gradient stops
     std::vector<stop> _stops = {};
+
+    /// An optional label string (non-empty will trigger label rendering)
+    std::string _label = "";
 
     /// Get a color from a scale parameter
     ///
@@ -241,6 +245,69 @@ struct font {
         if (not _style.empty()) {
             o_._attribute_map["font-style"] = _style;
         }
+    }
+};
+
+/// The label struct
+///
+struct label {
+    /// The horizontal alignment enum
+    enum class horizontal { left, center, right };
+
+    /// The vertical alignment enum
+    enum class vertical { top, center, bottom };
+
+    /// The label text
+    std::string _text = "";
+
+    /// The label horizontal alignment
+    horizontal _horizontal = horizontal::left;
+
+    /// The vertical horizontal alignment
+    vertical _vertical = vertical::bottom;
+
+    /// The font type of the label
+    font _font = font{};
+
+    /// The position
+    std::array<scalar, 2u> _position = {0., 0.};
+
+    /// Place the label at the position - assuming a bounding box
+    ///
+    /// @param lhc_ the left hand corner of the bounding box
+    /// @param ruc_ the right upper corner of the bounding box
+    void place(const std::array<scalar, 2u> &lhc_,
+                                const std::array<scalar, 2u> &rhc_) {
+
+
+        scalar x = 0.;
+        scalar y = 0.;
+
+        // First determine the y position
+        if (_vertical == vertical::top) {
+            y = rhc_[1] + 0.6 * _font._size;
+        } else if (_vertical == vertical::bottom) {
+            y = lhc_[1] - 1.1 * _font._size;
+        } else if (_vertical == vertical::center) {
+            y = 0.5 * (lhc_[1] + rhc_[1] - _font._size);
+        }
+
+        if (_horizontal == horizontal::left) {
+            x = lhc_[0];
+            if (_vertical == vertical::center) {
+                x -= 0.64 * _font._size * _text.size();
+            }
+        } else if (_horizontal == horizontal::right) {
+            x = rhc_[0] - 0.6 * _font._size * _text.size();
+            if (_vertical == vertical::center) {
+                x += 0.64 * _font._size * _text.size(); 
+            }
+        } else if (_horizontal == horizontal::center) {
+            x = 0.5 * (lhc_[0] + rhc_[0] - 0.6 * _font._size * _text.size());
+        }
+
+
+        _position =  {x, y};
     }
 };
 

--- a/core/include/actsvg/core/svg.hpp
+++ b/core/include/actsvg/core/svg.hpp
@@ -43,6 +43,8 @@ struct object {
         std::array<scalar, 2> _scale = {1., 1.};
     };
 
+    using bounding_box = std::array<std::array<scalar, 2u>, 2u>;
+
     /// SVG tag of the objec
     std::string _tag = "";
 
@@ -105,6 +107,18 @@ struct object {
     /// The object is an empty group
     bool is_empty_group() const {
         return (_tag == "g" and _sub_objects.empty());
+    }
+
+    /// Generate bounding box
+    ///
+    /// @note this is in the logical frame of the object and not the view frame
+    ///
+    /// @return a bounding box as left lower corner and upper right corner
+    bounding_box generate_bounding_box() const {
+        bounding_box bb = {};
+        bb[0u] = {_x_range[0], std::min(-_y_range[0], -_y_range[1])};
+        bb[1u] = {_x_range[1], std::max(-_y_range[0], -_y_range[1])};
+        return bb;
     }
 
     /** Add a sub object and respect the min/max range

--- a/meta/include/actsvg/display/materials.hpp
+++ b/meta/include/actsvg/display/materials.hpp
@@ -105,7 +105,7 @@ static inline svg::object surface_material(const std::string& id_,
     }
 
     svg::object gbox = draw::gradient_box(
-        id_ + "_gradient_box", m_._gradient_pos, m_._gradient_box, stops,
+        id_ + "_gradient_box", m_._gradient_pos, m_._gradient_box, stops, m_._gradient_label,
         m_._gradient_stroke, m_._gradient_font);
 
     m.add_object(g);

--- a/meta/include/actsvg/proto/material.hpp
+++ b/meta/include/actsvg/proto/material.hpp
@@ -90,6 +90,9 @@ struct surface_material {
     /// Gradient font
     style::font _gradient_font = style::font{};
 
+    /// Gradient label
+    style::label _gradient_label = style::label{};
+
     /// The info position
     point2 _info_pos = {0, 0};
 

--- a/tests/core/CMakeLists.txt
+++ b/tests/core/CMakeLists.txt
@@ -10,6 +10,7 @@ actsvg_add_test( core
   "gradient.cpp"
   "grids.cpp"
   "infobox.cpp"
+  "label.cpp"
   "line.cpp"
   "markers.cpp"
   "measures.cpp"

--- a/tests/core/gradient.cpp
+++ b/tests/core/gradient.cpp
@@ -83,6 +83,33 @@ TEST(core, gradient_box_vertical) {
     tstream.close();
 }
 
+TEST(core, gradient_box_vertical_label) {
+
+    svg::file ftemplate;
+
+    // Set a playground
+    auto pg = test::playground({-400, -400}, {400, 400});
+
+    auto g = draw::gradient_box(
+        "g_box", {100, 20}, {20, 200},
+        {{style::gradient::stop{0., style::color{style::rgb{0, 0, 255}}}, 0.},
+         {style::gradient::stop{0.45, style::color{style::rgb{0, 255, 0}}},
+          2.0},
+         {style::gradient::stop{0.75, style::color{style::rgb{255, 255, 0}}},
+          2.6},
+         {style::gradient::stop{1., style::color{style::rgb{255, 0, 0}}},
+          5.2}});
+
+    svg::file mfile;
+    mfile.add_object(pg);
+    mfile.add_object(g);
+
+    std::ofstream tstream;
+    tstream.open("test_core_gradient_box_vertical_label.svg");
+    tstream << mfile;
+    tstream.close();
+}
+
 TEST(core, gradient_box_horizontal) {
 
     svg::file ftemplate;
@@ -106,6 +133,35 @@ TEST(core, gradient_box_horizontal) {
 
     std::ofstream tstream;
     tstream.open("test_core_gradient_box_horizontal.svg");
+    tstream << mfile;
+    tstream.close();
+}
+
+
+TEST(core, gradient_box_horizontal_label) {
+
+    svg::file ftemplate;
+
+    // Set a playground
+    auto pg = test::playground({-400, -400}, {400, 400});
+
+    auto g = draw::gradient_box(
+        "g_box", {50, 50}, {200, 20},
+        {{style::gradient::stop{0., style::color{style::rgb{0, 0, 255}}}, 0.},
+         {style::gradient::stop{0.25, style::color{style::rgb{0, 255, 0}}},
+          1.3},
+         {style::gradient::stop{0.75, style::color{style::rgb{255, 255, 0}}},
+          2.6},
+         {style::gradient::stop{1., style::color{style::rgb{255, 0, 0}}},
+          5.2}},
+          style::label{"arb. unit", style::label::horizontal::right, style::label::vertical::top});
+
+    svg::file mfile;
+    mfile.add_object(pg);
+    mfile.add_object(g);
+
+    std::ofstream tstream;
+    tstream.open("test_core_gradient_box_horizontal_label.svg");
     tstream << mfile;
     tstream.close();
 }

--- a/tests/core/label.cpp
+++ b/tests/core/label.cpp
@@ -1,0 +1,78 @@
+// This file is part of the actsvg packge.
+//
+// Copyright (C) 2023 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+
+#include "../common/playground.hpp"
+#include "actsvg/core/draw.hpp"
+
+using namespace actsvg;
+
+namespace {
+    // Helper function
+    void test_label(style::label::horizontal h, style::label::vertical v,
+                    const std::string& name) {
+        // Set a playground
+        auto pg = test::playground({-400, -400}, {400, 400});
+
+        // Write out the file
+        std::ofstream fo;
+        fo.open(std::string("test_core_label_"+name+".svg").c_str());
+
+        auto box = draw::rectangle("box", {200, 100}, 150, 20,
+                                   style::fill{style::color{{255, 0, 0}}});
+        auto [llc, urc] = box.generate_bounding_box();
+        auto l = style::label{name, h, v}; 
+        l.place(llc, urc);
+
+        svg::file of;
+        of.add_object(pg);
+        of.add_object(box);
+        of.add_object(draw::label("label", l));
+        fo << of;
+        fo.close();
+    }
+}
+
+TEST(core, label_left_bottom) {
+    test_label(style::label::horizontal::left, style::label::vertical::bottom,
+               "left_bottom");
+}
+
+TEST(core, label_right_bottom) {
+    test_label(style::label::horizontal::right, style::label::vertical::bottom,
+               "right_bottom");
+}
+
+TEST(core, label_left_top) {
+    test_label(style::label::horizontal::left, style::label::vertical::top,
+               "left_top");
+}
+
+TEST(core, label_right_top) {
+    test_label(style::label::horizontal::right, style::label::vertical::top,
+               "right_top");
+}
+
+TEST(core, label_center_center) {
+    test_label(style::label::horizontal::center, style::label::vertical::center,
+               "center_center");
+}
+
+TEST(core, label_left_center) {
+    test_label(style::label::horizontal::left, style::label::vertical::center,
+               "left_center");
+}
+
+TEST(core, label_right_center) {
+    test_label(style::label::horizontal::right, style::label::vertical::center,
+               "right_center");
+}

--- a/tests/meta/surface_materials.cpp
+++ b/tests/meta/surface_materials.cpp
@@ -116,6 +116,9 @@ TEST(proto, surface_material_r_phi) {
     m._gradient_box = {20, 300};
     m._gradient_font._size = 10;
 
+    m._gradient_label = style::label{"t/X0", style::label::horizontal::right,
+                                    style::label::vertical::top};
+
     auto sm_r_phi = display::surface_material("r_phi_material", m);
 
     svg::file file_sm_r_phi;


### PR DESCRIPTION
This adds the `style::label` struct and applies it to gradients at first.

It closes #70.

<img width="385" alt="Screenshot 2024-06-18 at 11 07 32" src="https://github.com/acts-project/actsvg/assets/26623879/8c9dd33e-2dbc-4196-a9d9-254bd8ef05ce">

<img width="671" alt="Screenshot 2024-06-18 at 11 30 00" src="https://github.com/acts-project/actsvg/assets/26623879/bbb8138d-c3d5-43b4-bfb8-bd0131c66bc2">
