### PR TITLE
fix: Avoid unused local typedef

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ project (actsvg VERSION 0.4.41 LANGUAGES CXX )
 set( CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard to use" )
 set( CMAKE_CXX_EXTENSIONS FALSE CACHE BOOL "Disable C++ extensions" )
 
-set(ACTSVG_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wshadow -Wno-unused-local-typedefs")
+set(ACTSVG_CXX_FLAGS "-Wall -Wextra -Wpedantic -Wshadow")
 # This adds some useful conversion checks like float-to-bool, float-to-int, etc.
 # However, at the moment this is only added to clang builds, since GCC's -Wfloat-conversion 
 # is much more aggressive and also triggers on e.g., double-to-float

--- a/meta/include/actsvg/display/sheets.hpp
+++ b/meta/include/actsvg/display/sheets.hpp
@@ -52,8 +52,6 @@ svg::object surface_sheet_xy(const std::string& id_,
     so._tag = "g";
     so._id = id_;
 
-    using point3 = typename point3_container::value_type;
-
     views::x_y x_y_view;
 
     std::vector<views::contour> contours = {range_contour(s_, fs_)};


### PR DESCRIPTION
This also removes the `-Wno-unused-local-typedefs` compile flag.