### PR TITLE
feat: annulus bounds with path (instead of vertices)

### DIFF
--- a/python/src/proto.cpp
+++ b/python/src/proto.cpp
@@ -107,15 +107,6 @@ void add_proto_module(context& ctx) {
                             // Set the predefined transform
                             sf._surface_transform =
                                 surface::transform3{translation, rotation};
-                            // Only x, y view will be transformed correctly
-                            point3 sfx = rotation[0];
-                            // Force the translation of the transofrm to 0
-                            sf._transform._tr = {0., 0.};
-                            scalar alpha = std::acos(sfx[0]) / M_PI * 180;
-                            if (sfx[1] < 0.) {
-                                alpha += 180.;
-                            }
-                            sf._transform._rot = {alpha, 0., 0.};
                         }
                         sf._fill = f;
                         sf._stroke = s;


### PR DESCRIPTION
Finally (now), the `AnnulusBounds` can be displayed as a graph instead of vertices.

![Screenshot 2024-08-16 at 09 18 37](https://github.com/user-attachments/assets/84c0d3de-732e-4e40-8380-c80802c5469e)
