### PR TITLE
feat: update clipping to respect view size

### DIFF
--- a/core/include/actsvg/core/svg.hpp
+++ b/core/include/actsvg/core/svg.hpp
@@ -214,8 +214,12 @@ struct file {
     /** Get the view box from the x-y range */
     std::array<scalar, 4> view_box() const;
 
-    /** Set a view box, this will overwrite the auto-determined one */
-    void set_view_box(const std::array<scalar, 4> &vb_);
+    /** Set a view box, this will overwrite the auto-determined one
+     *
+     * @param vb_ the view box to be set
+     * @param adjust_ if true, the width and height are adjusted
+     */
+    void set_view_box(const std::array<scalar, 4> &vb_, bool adjust_ = true);
 
     /** Write to ostream */
     friend std::ostream &operator<<(std::ostream &os_, const file &f_);

--- a/core/src/core/svg.cpp
+++ b/core/src/core/svg.cpp
@@ -156,8 +156,14 @@ std::array<scalar, 4> file::view_box() const {
     return vbox;
 }
 
-void file::set_view_box(const std::array<scalar, 4> &vbox_) {
+void file::set_view_box(const std::array<scalar, 4> &vbox_, bool adjust_) {
+    // Set the view box
     _view_box = vbox_;
+    if (adjust_) {
+        // Adjust the width and height
+        _width = vbox_[2];
+        _height = vbox_[3];
+    }
 }
 
 std::ostream &operator<<(std::ostream &os_, const file &f_) {

--- a/python/src/io.cpp
+++ b/python/src/io.cpp
@@ -45,12 +45,15 @@ void add_io_module(context& ctx) {
                 [](actsvg::svg::file& self, std::array<actsvg::scalar, 4> box) {
                     self.set_view_box(box);
                 })
-            .def("write", [](svg::file& self, const std::string& fn) {
-                std::ofstream fout;
-                fout.open(fn);
-                fout << self;
-                fout.close();
-            });
+            .def("write",
+                 [](svg::file& self, const std::string& fn) {
+                     std::ofstream fout;
+                     fout.open(fn);
+                     fout << self;
+                     fout.close();
+                 })
+            .def_readwrite("width", &svg::file::_width)
+            .def_readwrite("height", &svg::file::_height);
     }
 
     // The obj submodule: actsvg.io.obj


### PR DESCRIPTION
The file clipping did not set / update the figure size. This is happening now.