### PR TITLE
Fix: Material maps scale in scientific notation

### DIFF
--- a/core/include/actsvg/core/utils.hpp
+++ b/core/include/actsvg/core/utils.hpp
@@ -13,10 +13,19 @@
 #include <iostream>
 #include <sstream>
 #include <tuple>
+#include <vector>
+
+#include "actsvg/core/defs.hpp"
 
 namespace actsvg {
 
 namespace utils {
+
+// How to format values in string output
+enum class value_format : unsigned int {
+    e_scientific,
+    e_default,
+};
 
 /** Helper method to run enumerate(...) with structured binding
  * over STL type containers.
@@ -135,7 +144,8 @@ std::string id_to_url(const std::string &id_);
  *
  * @return a string
  */
-std::string to_string(const scalar &s_, size_t pr_ = 4);
+std::string to_string(const scalar &s_, size_t pr_ = 4,
+                      value_format f_ = value_format::e_default);
 
 /** Helper to format point2
  *

--- a/core/src/core/draw.cpp
+++ b/core/src/core/draw.cpp
@@ -1086,6 +1086,8 @@ svg::object gradient_box(
 
         // Create the tick value
         scalar value = std::get<1>(stops_[is]);
+        std::string val_str{
+            utils::to_string(value, 4, utils::value_format::e_scientific)};
 
         svg::object tval =
             vertical
@@ -1093,18 +1095,18 @@ svg::object gradient_box(
                       id_ + "_tick_val_" + std::to_string(is),
                       {static_cast<scalar>(p_[0] + w_ + 0.2 * font_._size),
                        p_[1] + h_ * s.first},
-                      {utils::to_string(value)}, font_)
+                      {val_str}, font_)
                 : draw::text(id_ + "_tick_val_" + std::to_string(is),
                              {p_[0] + w_ * s.first,
                               static_cast<scalar>(p_[1] - 1.2 * font_._size)},
-                             {utils::to_string(value)}, font_);
+                             {val_str}, font_);
         tval._sterile = true;
         tval._attribute_map["alignment-baseline"] = "middle";
         if (not vertical) {
             tval._attribute_map["text-anchor"] = "middle";
         }
         font_.attach_attributes(tval);
-        tval._field = {utils::to_string(value)};
+        tval._field = {std::move(val_str)};
         g.add_object(tval);
     }
 

--- a/core/src/core/style.cpp
+++ b/core/src/core/style.cpp
@@ -42,7 +42,7 @@ rgb gradient::rgb_from_scale(scalar s_) const {
         s_ < 0._scalar ? 0._scalar : (s_ > 1._scalar ? 1._scalar : s_);
     // find our stops
     unsigned int is = 1u;
-    for (; is <= _stops.size(); ++is) {
+    for (; is < _stops.size(); ++is) {
         if (_stops[is].first > s_reg) {
             break;
         }

--- a/core/src/core/utils.cpp
+++ b/core/src/core/utils.cpp
@@ -6,13 +6,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include "actsvg/core/utils.hpp"
+
 #include <cmath>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <tuple>
-
-#include "actsvg/core/defs.hpp"
 
 namespace actsvg {
 
@@ -21,8 +21,11 @@ std::string id_to_url(const std::string &id_) {
     return std::string("url(#") + id_ + ")";
 }
 
-std::string to_string(const scalar &s_, size_t pr_) {
+std::string to_string(const scalar &s_, size_t pr_, value_format f_) {
     std::stringstream sstream;
+    if (f_ == value_format::e_scientific) {
+        sstream << std::scientific;
+    }
     sstream << std::setprecision(pr_) << s_;
     return sstream.str();
 }


### PR DESCRIPTION
Fix an out of bounds exception on the gradient scale and then print material maps scale in scientific notation